### PR TITLE
support Predis 2.x and SDK 5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@ workflows:
   workflow:
     jobs:
       - linux-test:
+          matrix:
+              parameters:
+                  php-version: ["7.3", "7.4", "8.0", "8.1"]
+                  composer-dependencies: ["lowest", "highest"]
           name: PHP 7.3
           docker-image: cimg/php:7.3
       - linux-test:
@@ -16,11 +20,13 @@ workflows:
 jobs:
   linux-test:
     parameters:
-      docker-image:
+      php-version:
+        type: string
+      composer-dependencies:
         type: string
 
     docker:
-      - image: <<parameters.docker-image>>
+      - image: cimg/php:<<parameters.php-version>>
       - image: redis
 
     steps:
@@ -28,6 +34,13 @@ jobs:
       - run:
           name: install dependencies
           command: composer install --no-progress
+      - when:
+          condition:
+            equal: [ <<parameters.composer-dependencies>>, "lowest" ]
+          steps:
+            - run:
+                name: downgrade to lowest versions
+                command: composer update --prefer-lowest --prefer-stable
       - run: mkdir -p ./phpunit
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,6 @@ workflows:
               parameters:
                   php-version: ["7.3", "7.4", "8.0", "8.1"]
                   composer-dependencies: ["lowest", "highest"]
-          name: PHP 7.3
-          docker-image: cimg/php:7.3
-      - linux-test:
-          name: PHP 7.4
-          docker-image: cimg/php:7.4
-      - linux-test:
-          name: PHP 8.0
-          docker-image: cimg/php:8.0
 
 jobs:
   linux-test:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.3",
         "predis/predis": ">=1.0.0 <3.0.0",
-        "launchdarkly/server-sdk": "^4"
+        "launchdarkly/server-sdk": ">=4.0.0 <6.0.0"
     },
     "require-dev": {
         "launchdarkly/server-sdk-shared-tests": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "predis/predis": "^1",
+        "predis/predis": ">=1.0.0 <3.0.0",
         "launchdarkly/server-sdk": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
Our integration code doesn't rely on any Predis APIs that have actually changed between 1.x and 2.x. So I think all that's needed here is to relax the dependency constraint to allow both, and to make sure we're testing with both in CI.

There are Predis configuration options that have changed in 2.x, but that just means that if an application passes custom options through by setting `predis_options`, they need to set them correctly for whichever version of Predis the application is using.

I also relaxed the PHP SDK dependency to support the next major version, 5.0, because we're not introducing any internal API changes in that release that would affect this database integration.